### PR TITLE
Make state of ROI inputs be remembered to be used in the ROI Calculator

### DIFF
--- a/bariq-frontend/components/Navbar.js
+++ b/bariq-frontend/components/Navbar.js
@@ -1,10 +1,9 @@
 import styled from "styled-components";
-import LogoutIcon from "./sidebar-icons";
 
 const Nav = styled.nav`
   background: #1A1D6A;
   height: 60px;
-  width: 95vw;
+  width: 100%;
 `;
 
 const List = styled.ul`

--- a/bariq-frontend/components/RoiInput.js
+++ b/bariq-frontend/components/RoiInput.js
@@ -37,7 +37,6 @@ const StyledButton = styled.a`
   border-style: solid;
   border-width: 1.95px;
   transition: 0.5s;
-  text-color: black;
 
   &:hover {
     background: #2a81e5;
@@ -77,6 +76,9 @@ function RoiInput(props) {
   const [showModal, setShowModal] = useState(false);
 
   const handleOpenModal = () => {
+    console.log(props.fields);
+    // props.fields is an array of 25 integers
+    // TODO in the future: use the array to calculate the ROI
     setShowModal(true);
   };
 
@@ -91,10 +93,15 @@ function RoiInput(props) {
         type={"number"}
         required={true}
         value={props.value}
-        onChange={props.onChange}
+        onChange={(event) => {
+          const fields = props.fields
+          fields[index] = parseInt(event.target.value)
+          props.setFields([...fields])
+        }}
       />
     </div>
   ));
+
   return (
     <Wrapper>
       <form>{inputs}</form>

--- a/bariq-frontend/pages/roi-calculator.js
+++ b/bariq-frontend/pages/roi-calculator.js
@@ -29,7 +29,7 @@ const Title = styled.h1`
   text-align: center;
   font-size: 30px;
   height: 60px;
-  width: 100%;
+  width: 100vw;
   padding-top: 20px;
   padding-bottom: 100px;
   font-weight: bold;
@@ -39,26 +39,13 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: row;
 `;
-const RoiButton = styled.a`
-  color: #e7edf2;
-  background: #1a1d4a;
-  font-size: 20px;
-  padding: 5px 13px;
-  border-radius: 200px;
-  border-color: #1a1d4a;
-  border-style: solid;
-  border-width: 1.95px;
-  transition: 0.5s;
-  text-color: black;
 
-  &:hover {
-    background: #2a81e5;
-    color: #e7edf2;
-  }
-`;
-export default function CALC() {
+export default function RoiCalculator() {
   // Navigation
   const router = useRouter();
+
+  // Form fields
+  const [fields, setFields] = useState(Array(25).fill(0))
 
   // Authentication
   initFirebase();
@@ -92,7 +79,7 @@ export default function CALC() {
             <Title>ROI Calculator Input Form</Title>
             <h2>We should probably write something here</h2>
             <Container2>
-              <RoiInput />
+              <RoiInput fields={fields} setFields={setFields} />
             </Container2>
           </Centered>
         </Container>

--- a/bariq-frontend/pages/roi.js
+++ b/bariq-frontend/pages/roi.js
@@ -93,7 +93,7 @@ export default function ROI() {
             <Container2>
               <RoiPage />
             </Container2>
-            <a href="/calc">
+            <a href="/roi-calculator.js">
               <RoiButton> Go To Calculator</RoiButton>
             </a>
           </Centered>


### PR DESCRIPTION
- State of ROI inputs can now be remembered for future use in the calculation
- Rename calc.js to roi-calculator.js (new URL is now `.com/roi-calculator`
- Remove unused variables